### PR TITLE
Added multiple file extensions under one description

### DIFF
--- a/filedialogs/filedialogs.py
+++ b/filedialogs/filedialogs.py
@@ -50,7 +50,9 @@ def open_file_dialog(
     if ext is None:
         ext = "All Files\0*.*\0"
     else:
-        ext = "".join([f"{name}\0*.{extension}\0" for name, extension in ext])
+        extFilter = ""
+        for name, extensions in ext:
+            extFilter += f"{name}\0" + ";".join(f"*.{extension}" for extension in extensions) + '\0'
 
     try:
         file_path, _, _ = GetOpenFileNameW(
@@ -59,7 +61,7 @@ def open_file_dialog(
             Flags=flags,
             Title=title,
             MaxFile=2**16,
-            Filter=ext,
+            Filter=extFilter,
             DefExt=default_ext,
         )
 
@@ -108,7 +110,9 @@ def save_file_dialog(
     if ext is None:
         ext = "All Files\0*.*\0"
     else:
-        ext = "".join([f"{name}\0*.{extension}\0" for name, extension in ext])
+        extFilter = ""
+        for name, extensions in ext:
+            extFilter += f"{name}\0" + ";".join(f"*.{extension}" for extension in extensions) + '\0'
 
     try:
         file_path, _, _ = GetSaveFileNameW(
@@ -116,7 +120,7 @@ def save_file_dialog(
             File=default_name,
             Title=title,
             MaxFile=2**16,
-            Filter=ext,
+            Filter=extFilter,
             DefExt=default_ext,
         )
 

--- a/filedialogs/filedialogs.py
+++ b/filedialogs/filedialogs.py
@@ -52,7 +52,7 @@ def open_file_dialog(
     else:
         extFilter = ""
         for name, extensions in ext:
-            extFilter += f"{name}\0" + ";".join(f"*.{extension}" for extension in extensions) + '\0'
+            extFilter += f"{name}\0" + ";".join(f"*.{extension}" for extension in extensions) + "\0"
 
     try:
         file_path, _, _ = GetOpenFileNameW(
@@ -112,7 +112,7 @@ def save_file_dialog(
     else:
         extFilter = ""
         for name, extensions in ext:
-            extFilter += f"{name}\0" + ";".join(f"*.{extension}" for extension in extensions) + '\0'
+            extFilter += f"{name}\0" + ";".join(f"*.{extension}" for extension in extensions) + "\0"
 
     try:
         file_path, _, _ = GetSaveFileNameW(


### PR DESCRIPTION
[//]: # "Please read `CONTRIBUTING.md` before opening a pull request."

# Description
[//]: # "Describe the changes in this pull request here."

Changed else conditions for `ext is None`, using new variable `extFilter`. Changed for both save and open dialog functions. Allows dialogue to use multiple file extensions under one description, in compliance with Feature Request #4 with reference to https://www.markjour.com/docs/pywin32-docs/win32gui__GetOpenFileNameW_meth.html.

Changed string passed to `win32gui.GetOpenFileNameW` and `win32gui.GetSaveFileNameW`. Changed format of `ext` to be `List[Tuple[str, Tuple[str, ...]]]`, or 
```python
[
  ("Description",
    ("extensions", ...)
  ), 
...]
```
Variable passed to parameter `Filter` is now `extFilter`, not `ext`.

[//]: # "Use '#123' to refer to issue number 123."
Closes Issue: #4

---
