### PR TITLE
Final: Multiple File Extensions Under One Description

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,7 @@ if openfolder:
 * directory: str - Directory to open file dialog in. Default is the current working directory.
 * default_name: str - Default file name on dialog open. Default is empty.
 * default_ext: str - Default file extension on dialog open. Default is no extension.
-* ext: list[tuple[str, str]] or list[tuple[str, tuple[str, ...]]] - List of available extensions as (description, extension) or (description, (extensions,)) tuples. Default is ("All files", "*").
+* ext: list[tuple[str, str | tuple[str, ...]]] - List of available extensions as (description, extension) or (description, (extensions,)) tuples. Default is ("All files", "*").
 * multiselect: bool - Allow multiple files to be selected. Default is False.
 
 Returns: Path to a file to open if multiselect=False. List of the paths to files which should be opened if multiselect=True. None if file open dialog canceled.
@@ -65,7 +65,7 @@ Raises: IOError - File open dialog failed.
 * directory: str - Directory to open file dialog in. Default is the current working directory.
 * default_name: str - Default file name on dialog open. Default is empty.
 * default_ext: str - Default file extension on dialog open. Default is no extension.
-* ext: list[tuple[str, str]] or list[tuple[str, tuple[str, ...]]] - List of available extensions as (description, extension) or (description, (extensions,)) tuples. Default is ("All files", "*").
+* ext: list[tuple[str, str | tuple[str, ...]]] - List of available extensions as (description, extension) or (description, (extensions,)) tuples. Default is ("All files", "*").
 
 Returns: Path file should be save to. None if file save dialog canceled.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,7 @@ if openfolder:
 * directory: str - Directory to open file dialog in. Default is the current working directory.
 * default_name: str - Default file name on dialog open. Default is empty.
 * default_ext: str - Default file extension on dialog open. Default is no extension.
-* ext: list[tuple[str, str]] - List of available extensions as (description, extension) tuples. Default is ("All files", "*").
+* ext: list[tuple[str, str]] or list[tuple[str, tuple[str, ...]]] - List of available extensions as (description, extension) or (description, (extensions,)) tuples. Default is ("All files", "*").
 * multiselect: bool - Allow multiple files to be selected. Default is False.
 
 Returns: Path to a file to open if multiselect=False. List of the paths to files which should be opened if multiselect=True. None if file open dialog canceled.
@@ -65,7 +65,7 @@ Raises: IOError - File open dialog failed.
 * directory: str - Directory to open file dialog in. Default is the current working directory.
 * default_name: str - Default file name on dialog open. Default is empty.
 * default_ext: str - Default file extension on dialog open. Default is no extension.
-* ext: list[tuple[str, str]] - List of available extensions as (description, extension) tuples. Default is ("All files", "*").
+* ext: list[tuple[str, str]] or list[tuple[str, tuple[str, ...]]] - List of available extensions as (description, extension) or (description, (extensions,)) tuples. Default is ("All files", "*").
 
 Returns: Path file should be save to. None if file save dialog canceled.
 

--- a/filedialogs/filedialogs.py
+++ b/filedialogs/filedialogs.py
@@ -50,7 +50,9 @@ def open_file_dialog(
     if ext is None:
         ext = "All Files\0*.*\0"
     else:
-        ext = "".join([f"{name}\0*.{extension}\0" for name, extension in ext])
+        extFilter = ""
+        for name, extensions in ext:
+            extFilter += f"{name}\0" + ";".join(f"*.{extension}" for extension in extensions) + '\0'
 
     try:
         file_path, _, _ = GetOpenFileNameW(
@@ -59,7 +61,7 @@ def open_file_dialog(
             Flags=flags,
             Title=title,
             MaxFile=2**16,
-            Filter=ext,
+            Filter=extFilter,
             DefExt=default_ext,
         )
 
@@ -108,7 +110,9 @@ def save_file_dialog(
     if ext is None:
         ext = "All Files\0*.*\0"
     else:
-        ext = "".join([f"{name}\0*.{extension}\0" for name, extension in ext])
+        extFilter = ""
+        for name, extensions in ext:
+            extFilter += f"{name}\0" + ";".join(f"*.{extension}" for extension in extensions) + '\0'
 
     try:
         file_path, _, _ = GetSaveFileNameW(
@@ -116,7 +120,7 @@ def save_file_dialog(
             File=default_name,
             Title=title,
             MaxFile=2**16,
-            Filter=ext,
+            Filter=extFilter,
             DefExt=default_ext,
         )
 

--- a/filedialogs/filedialogs.py
+++ b/filedialogs/filedialogs.py
@@ -20,7 +20,7 @@ def open_file_dialog(
     directory: Optional[str] = None,
     default_name: str = "",
     default_ext: str = "",
-    ext: List[Tuple[str, Tuple[str, ...]]] | List[Tuple[str, str]] = None,
+    ext: List[Tuple[str, str | Tuple[str, ...]]] = None,
     multiselect: bool = False,
 ) -> Union[str, List[str], None]:
     """Open a file open dialog at a specified directory.
@@ -93,7 +93,7 @@ def save_file_dialog(
     directory: Optional[str] = None,
     default_name: str = "",
     default_ext: str = "",
-    ext: List[Tuple[str, Tuple[str, ...]]] | List[Tuple[str, str]] = None,
+    ext: List[Tuple[str, str | Tuple[str, ...]]] = None,
 ) -> Optional[str]:
     """Open a file save dialog at a specified directory.
 

--- a/filedialogs/filedialogs.py
+++ b/filedialogs/filedialogs.py
@@ -56,7 +56,7 @@ def open_file_dialog(
             if isinstance(extensions, str):
                 ext_filter += f"{name}\0*.{extensions}\0"
                 continue
-            ext_filter += f"{name}\0" + ";".join(f"*.{extension}" for extension in extensions) + '\0'
+            ext_filter += f"{name}\0" + ";".join(f"*.{extension}" for extension in extensions) + "\0"
         ext = ext_filter
 
     try:
@@ -121,7 +121,7 @@ def save_file_dialog(
             if isinstance(extensions, str):
                 ext_filter += f"{name}\0*.{extensions}\0"
                 continue
-            ext_filter += f"{name}\0" + ";".join(f"*.{extension}" for extension in extensions) + '\0'
+            ext_filter += f"{name}\0" + ";".join(f"*.{extension}" for extension in extensions) + "\0"
         ext = ext_filter
 
     try:


### PR DESCRIPTION
# Description
Changed else conditions for `ext is None`, using new variable `ext_filter`. Changed for both save and open dialog functions. Allows dialogue to use multiple file extensions under one description, in compliance with Feature Request https://github.com/MrThearMan/filedialogs/issues/4 with reference to https://www.markjour.com/docs/pywin32-docs/win32gui__GetOpenFileNameW_meth.html.

Changed string passed to `win32gui.GetOpenFileNameW` and `win32gui.GetSaveFileNameW`. Changed format of `ext` also accept `List[Tuple[str, Tuple[str, ...]]]`, or
```python
[
  ("Description",
    ("extensions", ...)
  ), 
...]
```
Variable passed to parameter Filter is still `ext`, but new variable `ext_filter` declared if else condition for `ext is None` is met.
Added new type inference and descriptions to `.\docs\index.md`. 

Closes Issue: https://github.com/MrThearMan/filedialogs/pull/5
Resolves draft pull request #5, including compliance by:

1. Compliance w/ PEP-8; Changed `camelCase` to `snake_case` for `extFilter` --> `ext_filter`
2. Changed `Filter` parameter for `win32gui.GetOpenFileNameW, GetSaveFileNameW` to take local variable `ext`, not `extFilter` to avoid `UnboundLocalError`
3. Compliance w/ PEP-484; Added new type hint for `ext`
4. Reintroduced functionality for previous `ext` format: `List[Tuple[str, str]]` to allow single extension descriptions (Compliance w/ PEP-387; Backwards Compatibility. Also for ease of use.)
5. Added new type hints to `.\docs\index.md` with descriptions of new format.

Closes Issue: https://github.com/MrThearMan/filedialogs/issues/4
